### PR TITLE
Cleanup of compiler warnings

### DIFF
--- a/src/main/java/com/eventswarm/events/HttpRequestEvent.java
+++ b/src/main/java/com/eventswarm/events/HttpRequestEvent.java
@@ -17,11 +17,7 @@ package com.eventswarm.events;
 
 import com.eventswarm.abstractions.ValueRetriever;
 
-import java.net.InetSocketAddress;
-import java.net.URI;
 import java.util.Date;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Interface for events created as a result of an HTTP request

--- a/src/main/java/com/eventswarm/events/jdo/JdoEvent.java
+++ b/src/main/java/com/eventswarm/events/jdo/JdoEvent.java
@@ -282,7 +282,7 @@ public class JdoEvent implements Event {
     }
 
     private boolean idEquals(Event event) {
-        return this.getHeader().madeId().equals(event.getHeader().madeId());
+        return this.getHeader().getEventId().equals(event.getHeader().getEventId());
     }
 
     private boolean timeEquals(Event event) {
@@ -292,7 +292,7 @@ public class JdoEvent implements Event {
     /** Use ID string as basis for hashcode */
     @Override
     public int hashCode() {
-        return this.header.madeId().hashCode();
+        return this.header.getEventId().hashCode();
     }
 
     @Override

--- a/src/main/java/com/eventswarm/events/jdo/JdoEventPart.java
+++ b/src/main/java/com/eventswarm/events/jdo/JdoEventPart.java
@@ -22,7 +22,6 @@
 
 package com.eventswarm.events.jdo;
 
-import java.util.Set;
 import com.eventswarm.util.*;
 import com.eventswarm.events.*;
 

--- a/src/main/java/com/eventswarm/events/jdo/JdoHeader.java
+++ b/src/main/java/com/eventswarm/events/jdo/JdoHeader.java
@@ -262,7 +262,7 @@ public class JdoHeader extends JdoEventPart implements Header {
         // Adequately handle inReplyTo event
         if (isReply()) {
             string.append("inReplyTo = ");
-            string.append(getInReplyTo().getHeader().madeId());
+            string.append(getInReplyTo().getHeader().getEventId());
         }
         else {
             string.append("inReplyTo = null");

--- a/src/main/java/com/eventswarm/events/jdo/OrgJsonEvent.java
+++ b/src/main/java/com/eventswarm/events/jdo/OrgJsonEvent.java
@@ -62,9 +62,10 @@ public class OrgJsonEvent extends JdoEvent implements JsonEvent<JSONObject> {
      * @param header
      * @param eventParts
      */
+    @SuppressWarnings("unchecked") // TODO: fix the use of generics to avoid unchecked casts
     public OrgJsonEvent(Header header, Map<String, EventPart> eventParts) {
         super(header, eventParts);
-        this.json = ((JdoPartWrapper<JSONObject>)eventParts.get(JSON_PART_NAME)).getWrapped();
+         this.json = ((JdoPartWrapper<JSONObject>)eventParts.get(JSON_PART_NAME)).getWrapped();
     }
 
     protected void construct(Header header, JSONObject json) {

--- a/src/main/java/com/eventswarm/events/jdo/XmlEventImpl.java
+++ b/src/main/java/com/eventswarm/events/jdo/XmlEventImpl.java
@@ -69,6 +69,7 @@ public class XmlEventImpl extends JdoEvent implements XmlEvent {
         eventParts.put(XML_PART_NAME, new JdoPartWrapper<Node>(xml));
     }
 
+    @SuppressWarnings("unchecked") // TODO: fix the use of generics to avoid unchecked casts
     public XmlEventImpl(Header header, Map<String, EventPart> eventParts) {
         super(header, eventParts);
         this.xml = ((JdoPartWrapper<Document>)eventParts.get(XML_PART_NAME)).getWrapped();

--- a/src/main/java/com/eventswarm/eventset/EventSet.java
+++ b/src/main/java/com/eventswarm/eventset/EventSet.java
@@ -114,7 +114,7 @@ public class EventSet implements MutablePassThru, Iterable<Event>, Clear {
         NavigableSet<Event> set;
         lock.readLock().lock();
         try {
-            set = (NavigableSet<Event>) this.eventSet.clone();
+            set = new TreeSet<Event>(this.eventSet);
         } finally {
             lock.readLock().unlock();
         }

--- a/src/main/java/com/eventswarm/expressions/ANDExpression.java
+++ b/src/main/java/com/eventswarm/expressions/ANDExpression.java
@@ -290,7 +290,7 @@ public class ANDExpression extends AbstractEventExpression implements ComplexExp
         for (int i=0; i < this.eventSets.size(); i++) {
             if (eventSets.get(i).contains(event)) {
                 log.debug("Creating " + parts.toString());
-                ArrayList<SortedSet<Event>> clone = (ArrayList<SortedSet<Event>>) parts.clone();
+                ArrayList<SortedSet<Event>> clone = new ArrayList<SortedSet<Event>>(parts);
                 // replace the current set with a set containing only the new event
                 clone.remove(i);
                 clone.add(i, singleton);

--- a/src/main/java/com/eventswarm/schedules/IntervalSchedule.java
+++ b/src/main/java/com/eventswarm/schedules/IntervalSchedule.java
@@ -26,7 +26,6 @@ package com.eventswarm.schedules;
  * @author andyb
  */
 import com.eventswarm.util.Interval;
-import com.eventswarm.util.IntervalUnit;
 import java.util.Date;
 
 public class IntervalSchedule extends Schedule {

--- a/src/test/java/com/eventswarm/channels/CSVChannelTest.java
+++ b/src/test/java/com/eventswarm/channels/CSVChannelTest.java
@@ -20,7 +20,6 @@ import com.eventswarm.AddEventTrigger;
 import com.eventswarm.events.CSVEvent;
 import com.eventswarm.events.Event;
 import com.eventswarm.events.jdo.JdoCSVEvent;
-import com.eventswarm.events.jdo.JdoCSVEvent;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.*;

--- a/src/test/java/com/eventswarm/channels/HttpClientTest.java
+++ b/src/test/java/com/eventswarm/channels/HttpClientTest.java
@@ -2,8 +2,6 @@ package com.eventswarm.channels;
 
 import org.json.JSONObject;
 import org.json.JSONTokener;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
 import org.junit.Test;
 import org.junit.Before;
 

--- a/src/test/java/com/eventswarm/channels/JsonChannelTest.java
+++ b/src/test/java/com/eventswarm/channels/JsonChannelTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 import java.io.InputStream;
-import java.io.StringBufferInputStream;
+import java.io.ByteArrayInputStream;
 import java.util.Date;
 
 /**
@@ -36,7 +36,7 @@ public class JsonChannelTest implements FromJson {
 
     @Test
     public void testNextSingle() throws Exception {
-        InputStream stream = new StringBufferInputStream("{a:1, b:2}");
+        InputStream stream = new ByteArrayInputStream("{a:1, b:2}".getBytes());
         JsonChannel channel = new JsonChannel(stream);
         Event event = channel.next();
         assertTrue(JsonEvent.class.isInstance(event));
@@ -48,7 +48,7 @@ public class JsonChannelTest implements FromJson {
 
     @Test
     public void testNextMultiple() throws Exception {
-        InputStream stream = new StringBufferInputStream("{a:1, b:2}{a:2, b:1}");
+        InputStream stream = new ByteArrayInputStream("{a:1, b:2}{a:2, b:1}".getBytes());
         JsonChannel channel = new JsonChannel(stream);
         channel.next();
         Event event = channel.next();
@@ -62,7 +62,7 @@ public class JsonChannelTest implements FromJson {
 
     @Test
     public void testNextEmpty() throws Exception {
-        InputStream stream = new StringBufferInputStream("");
+        InputStream stream = new ByteArrayInputStream("".getBytes());
         JsonChannel channel = new JsonChannel(stream);
         Event event = channel.next();
         assertNull(event);
@@ -71,10 +71,10 @@ public class JsonChannelTest implements FromJson {
 
     @Test
     public void setTokener() throws Exception {
-        InputStream stream = new StringBufferInputStream("{a:1, b:2}");
+        InputStream stream = new ByteArrayInputStream("{a:1, b:2}".getBytes());
         JsonChannel channel = new JsonChannel(stream);
         channel.next();
-        channel.setTokener(new StringBufferInputStream("{a:2, b:1}"));
+        channel.setTokener(new ByteArrayInputStream("{a:2, b:1}".getBytes()));
         Event event = channel.next();
         assertTrue(JsonEvent.class.isInstance(event));
         assertEquals(2, ((JsonEvent<?>) event).getInt("a"));
@@ -85,7 +85,7 @@ public class JsonChannelTest implements FromJson {
 
     @Test
     public void testRegisterConstructor() throws Exception {
-        InputStream stream = new StringBufferInputStream("{typeId: 'JsonChannelTest', a:1, b:2}");
+        InputStream stream = new ByteArrayInputStream("{typeId: 'JsonChannelTest', a:1, b:2}".getBytes());
         JsonChannel channel = new JsonChannel(stream);
         channel.registerConstructor(TYPE_ID, this);
         Event event = channel.next();
@@ -95,7 +95,7 @@ public class JsonChannelTest implements FromJson {
 
     @Test
     public void testUnregisterConstructor() throws Exception {
-        InputStream stream = new StringBufferInputStream("{typeId: 'JsonChannelTest', a:1, b:2}{typeId: 'JsonChannelTest', a:2, b:1}");
+        InputStream stream = new ByteArrayInputStream("{typeId: 'JsonChannelTest', a:1, b:2}{typeId: 'JsonChannelTest', a:2, b:1}".getBytes());
         JsonChannel channel = new JsonChannel(stream);
         channel.registerConstructor(TYPE_ID, this);
         Event event1 = channel.next();

--- a/src/test/java/com/eventswarm/channels/JsonHttpEventFactoryTest.java
+++ b/src/test/java/com/eventswarm/channels/JsonHttpEventFactoryTest.java
@@ -39,7 +39,6 @@ import static org.junit.Assert.assertTrue;
  * User: andyb
  */
 public class JsonHttpEventFactoryTest {
-    private static String TEST_SOURCE = "JsonEventFactoryTest";
     private InetSocketAddress address;
     Map<String,List<String>> headers = new HashMap<String,List<String>>();
 

--- a/src/test/java/com/eventswarm/events/jdo/JdoEventURLTest.java
+++ b/src/test/java/com/eventswarm/events/jdo/JdoEventURLTest.java
@@ -23,8 +23,6 @@
 package com.eventswarm.events.jdo;
 
 import junit.framework.*;
-import com.eventswarm.events.EventURL;
-import org.apache.log4j.Logger;
 import java.net.URL;
 
 /**


### PR DESCRIPTION
* Removed deprecated use of `madeId` and StringInputBufferStream. 
* Removed unused imports. 
* Fixed some unchecked casts, ignored some harder ones (created TODOs)
* A few local config changes to address warnings about accessible APIs (in particular the com.sun.net.httpserver classes)