### PR TITLE
Fixed bugs relating to SequenceExpressions containing Activity matching expressions

### DIFF
--- a/src/main/java/com/eventswarm/events/jdo/JdoActivity.java
+++ b/src/main/java/com/eventswarm/events/jdo/JdoActivity.java
@@ -60,9 +60,9 @@ public class JdoActivity extends JdoEvent implements Activity {
     /**
      * Order an atomic Event against this Activity
      *
-     * An event is before an activity if it's timestamp is before the start of the activity.
-     * An event is after an activity is it's timestamp is after the end of the activity.
-     * An event is concurrent if it's timestamp is within the duration of the activity.
+     * An activity is after an event if the event is before the start of the activity.
+     * An activity is before an event if the event is after the end of the activity.
+     * An activity is concurrent if the event is within the duration of the activity.
      *
      * If a non-atomic event is passed, this method will call the alternate Activity-specific ordering method
      *
@@ -75,12 +75,14 @@ public class JdoActivity extends JdoEvent implements Activity {
         if (Activity.class.isInstance(event)) {
             // throw to the Activity implementation if not an atomic event
             return this.order((Activity) event);
-        } else if (event.getHeader().getTimestamp().before(this.getStart())) {
-            return -1;
-        } else if (event.getHeader().getTimestamp().after(this.getEnd())) {
-            return 1;
         } else {
-            return 0;
+            if (this.last().isBefore(event)) {
+                return -1;
+            } else if (event.isBefore(this.first())) {
+                return 1;
+            } else {
+                return 0;
+            }
         }
     }
 
@@ -94,9 +96,9 @@ public class JdoActivity extends JdoEvent implements Activity {
      * TODO: make this causal rather than based on timestamps, very complex
      */
     public int order(Activity activity) {
-        if (activity.getEnd().before(this.getStart())) {
+        if (this.last().isBefore(activity.first())) {
             return -1;
-        } else if (activity.getStart().after(this.getEnd())) {
+        } else if (this.first().isAfter(activity.last())) {
             return 1;
         } else {
             return 0;

--- a/src/main/java/com/eventswarm/events/jdo/JdoActivity.java
+++ b/src/main/java/com/eventswarm/events/jdo/JdoActivity.java
@@ -188,6 +188,14 @@ public class JdoActivity extends JdoEvent implements Activity {
     }
 
     /**
+     * Override event toString so we print embedded events
+     */
+    @Override
+    public String toString() {
+        return getEvents().toString();
+    }
+
+    /**
      * Provide convenience method to return the set of events
      *
      * @return

--- a/src/main/java/com/eventswarm/events/jdo/JdoHeader.java
+++ b/src/main/java/com/eventswarm/events/jdo/JdoHeader.java
@@ -255,6 +255,7 @@ public class JdoHeader extends JdoEventPart implements Header {
         // Output the fields
         string.append("eventId = ");         string.append(madeId().toString());     string.append(", ");
         string.append("timestamp = ");      string.append(getTimestamp().toString());  string.append(", ");
+        string.append("millis = ");         string.append(getTimestamp().getTime());  string.append(", ");
         string.append("sequenceNumber = "); string.append(getSequenceNumber());        string.append(", ");
         string.append("source = ");         string.append(getSource().getSourceId());  string.append(", ");
         string.append("isReply = ");        string.append(isReply());                  string.append(", ");

--- a/src/main/java/com/eventswarm/expressions/ANDExpression.java
+++ b/src/main/java/com/eventswarm/expressions/ANDExpression.java
@@ -158,6 +158,7 @@ public class ANDExpression extends AbstractEventExpression implements ComplexExp
         try {
             hasMatched = false;
             for (Expression expr : expressions) {
+                log.debug("Checking for match with " + expr.toString());
                 expr.execute(trigger, event);
             }
         } finally {

--- a/src/main/java/com/eventswarm/expressions/ValueGradientExpression.java
+++ b/src/main/java/com/eventswarm/expressions/ValueGradientExpression.java
@@ -36,12 +36,6 @@ import org.apache.log4j.Logger;
  * possibly be added out-of-order. Not super-efficient for long sequences, but
  * simple and reliable. 
  * 
- * Since `isTrue` only relates to the current set of events, 
- * the match set retained for this expression is set to 1 by default. The
- * `setLimit()` method can be used to hold more matches, but be aware that all
- * matches will be included in combinations returned by an ANDExpression or 
- * SequenceExpression, which could be misleading.
- * 
  * Note that any value retriever returning a Comparable value can be used,
  * although we anticipate this will mostly be used with numeric values.
  * 
@@ -75,7 +69,6 @@ public class ValueGradientExpression<T extends Comparable<T>> extends AbstractEv
     this.direction = direction;
     sequence.registerAction((RemoveEventAction) this);
     values = new HashMap<Event, T>();
-    setLimit(1);
   }
 
   /**
@@ -111,13 +104,13 @@ public class ValueGradientExpression<T extends Comparable<T>> extends AbstractEv
     }
   }
 
-  /**
-   * This expression is currently true if the isGradient check returns true
-   */
-  @Override
-  public boolean isTrue() {
-    return isGradient();
-  }
+  // /**
+  //  * This expression is currently true if the isGradient check returns true
+  //  */
+  // @Override
+  // public boolean isTrue() {
+  //   return isGradient();
+  // }
 
   /**
    * True if the specified event is part of the sequence and we currently have a gradient
@@ -133,19 +126,23 @@ public class ValueGradientExpression<T extends Comparable<T>> extends AbstractEv
 
   /**
    * Check to see if the current set of events matches the gradient required (up,
-   * down, flat)
+   * down, flat) and has the required length
    * 
    * @return true if the events in the sequence are up/down/flat
    */
   private boolean isGradient() {
-    Iterator<Event> iter = sequence.iterator();
-    T last = values.get(iter.next());
-    boolean gradient = true;
-    while (iter.hasNext() && gradient) {
-      T next = values.get(iter.next());
-      gradient = (next.compareTo(last) == direction);
-      last = next;
+    if (sequence.isFilling()) {
+      return false;
+    } else {
+      Iterator<Event> iter = sequence.iterator();
+      T last = values.get(iter.next());
+      boolean gradient = true;
+      while (iter.hasNext() && gradient) {
+        T next = values.get(iter.next());
+        gradient = (next.compareTo(last) == direction);
+        last = next;
+      }
+      return gradient;
     }
-    return gradient;
   }
 }

--- a/src/test/java/com/eventswarm/events/jdo/JdoActivityTest.java
+++ b/src/test/java/com/eventswarm/events/jdo/JdoActivityTest.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2007-2014 Ensift Pty Ltd as trustee for the Avaz Trust and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+/*
+ * JdoEventTest.java
+ * JUnit based test
+ *
+ * Created on May 11, 2007, 8:57 AM
+ */
+
+package com.eventswarm.events.jdo;
+
+import org.junit.Test;
+import org.junit.Before;
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+import com.eventswarm.events.*;
+import com.eventswarm.eventset.EventSet;
+
+import java.util.*;
+
+public class JdoActivityTest {
+      
+  Map<String,EventPart> partsEmpty;
+  Event ea, ea1, ea2, ea3, eb1, eb2, eb3;
+
+  @Before
+  public void setUp() throws Exception {
+      // Various sets of EventParts
+      partsEmpty = new HashMap<String,EventPart>();
+      ea = new JdoEvent(new JdoHeader(new Date(), 0, new JdoSource("A")), partsEmpty);
+
+              
+      // create some other timestamps
+      Calendar cal = new GregorianCalendar(1999, 1, 1);
+      Date oldTs = cal.getTime();
+      Date ts = new Date();
+      Date newTs = new Date(ts.getTime()+1);
+      
+      // various headers with diferent timestamps for comparison
+      ea1 = new JdoEvent(new JdoHeader(ts, 0, new JdoSource("A")), partsEmpty);
+      ea2 = new JdoEvent(new JdoHeader(ts, 1, new JdoSource("A")), partsEmpty);
+      ea3 = new JdoEvent(new JdoHeader(newTs, 0, new JdoSource("A")), partsEmpty);
+      eb1 = new JdoEvent(new JdoHeader(oldTs, 0, new JdoSource("B")), partsEmpty);
+      eb2 = new JdoEvent(new JdoHeader(ts, 0, new JdoSource("B")), partsEmpty);
+      eb3 = new JdoEvent(new JdoHeader(newTs, 0, new JdoSource("B")), partsEmpty);
+  }
+
+  @Test
+  public void testEventBeforeActivity() {
+    Activity subject = makeActivity(ea3, eb3);
+    assertTrue(ea1.isBefore(subject));
+    assertFalse(ea1.isAfter(subject));
+    assertFalse(ea1.isConcurrent(subject));
+  }
+
+  @Test
+  public void testEventAfterActivity() {
+    Activity subject = makeActivity(eb1, ea1);
+    assertTrue(eb3.isAfter(subject));
+    assertFalse(eb3.isBefore(subject));
+    assertFalse(eb3.isConcurrent(subject));
+  }
+
+  @Test
+  public void testActivityAfterEvent() {
+    Activity subject = makeActivity(ea3, eb3);
+    assertTrue(subject.isAfter(ea1));
+    assertFalse(subject.isBefore(ea1));
+    assertFalse(subject.isConcurrent(ea1));
+  }
+
+  @Test
+  public void testActivityBeforeEvent() {
+    Activity subject = makeActivity(eb1, ea1);
+    assertTrue(subject.isBefore(eb3));
+    assertFalse(subject.isAfter(eb3));
+    assertFalse(subject.isConcurrent(eb3));
+  }
+
+  @Test
+  public void testActivityConcurrentEvent() {
+    Activity subject = makeActivity(eb1, ea2);
+    assertTrue(subject.isConcurrent(eb2));
+    assertFalse(subject.isAfter(eb2));
+    assertFalse(subject.isBefore(eb2));
+  }
+
+  @Test
+  public void testEventConcurrentActivity() {
+    Activity subject = makeActivity(eb1, ea2);
+    assertTrue(eb2.isConcurrent(subject));
+    assertFalse(eb2.isAfter(subject));
+    assertFalse(eb2.isBefore(subject));
+  }
+
+  @Test
+  public void testActivityBefore() {
+    Activity first = makeActivity(eb1, ea1);
+    Activity second = makeActivity(ea3, eb3);
+    assertTrue(first.isBefore(second));
+    assertFalse(first.isAfter(second));
+    assertFalse(first.isConcurrent(second));
+  }
+
+  @Test
+  public void testActivityAfter() {
+    Activity first = makeActivity(eb1, ea1);
+    Activity second = makeActivity(ea3, eb3);
+    assertTrue(second.isAfter(first));
+    assertFalse(second.isBefore(first));
+    assertFalse(second.isConcurrent(first));
+  }
+
+  @Test
+  public void testActivityConcurrent() {
+    Activity a1 = makeActivity(ea1, ea2);
+    Activity a2 = makeActivity(eb2, eb3);
+    assertFalse(a1.isBefore(a2));
+    assertFalse(a2.isBefore(a1));
+    assertFalse(a1.isAfter(a2));
+    assertFalse(a2.isAfter(a1));
+    assertTrue(a1.isConcurrent(a2));
+    assertTrue(a2.isConcurrent(a1));
+  }
+
+  public Activity makeActivity(Event e1, Event e2) {
+    return new JdoActivity(new TreeSet<Event>(Arrays.asList(new Event[] {e1,e2})));
+  }
+}

--- a/src/test/java/com/eventswarm/expressions/ANDExpressionTest.java
+++ b/src/test/java/com/eventswarm/expressions/ANDExpressionTest.java
@@ -23,6 +23,8 @@ import com.eventswarm.events.Event;
 import com.eventswarm.events.jdo.JdoCombination;
 import com.eventswarm.eventset.EventSet;
 import junit.framework.TestCase;
+import org.junit.Test;
+
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -101,28 +103,34 @@ public class ANDExpressionTest extends TestCase {
 
     }
 
+    @Test
     public void testIsTrue_empty() throws Exception {
         assertTrue(and0.isTrue());
     }
 
+    @Test
     public void testIsTrue_1expr_0event() throws Exception {
         assertFalse(and1.isTrue());
     }
 
+    @Test
     public void testIsTrue_2expr_0event() throws Exception {
         assertFalse(and2.isTrue());
     }
 
+    @Test
     public void testGetPartsAsList_empty() throws Exception {
         assertTrue(and0.getPartsAsList().size() == 0);
     }
 
+    @Test
     public void testGetPartsAsList_single() throws Exception {
         List<EventExpression> parts = and1.getPartsAsList();
         assertEquals(1, parts.size());
         assertEquals(expr_true1, parts.get(0));
     }
 
+    @Test
     public void testGetPartsAsList_multiple() throws Exception {
         List<EventExpression> parts =  and2.getPartsAsList();
         assertTrue(parts.size() == 2);
@@ -130,12 +138,14 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(parts.get(1) == expr_true3);
     }
 
+    @Test
     public void testAddEventExecute_empty() throws Exception {
         and0.execute((AddEventTrigger) null, event1);
         assertTrue(and0.isTrue());
         assertTrue(and0.getMatchEvents().size() == 0);
     }
 
+    @Test
     public void testAddEventExecute_1event_match() throws Exception {
         ANDExpression expr = and1;
         expr.execute((AddEventTrigger) null, event1);
@@ -146,6 +156,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(matchSets.get(0).contains(event1));
     }
 
+    @Test
     public void testAddEventExecute_1event_nomatch() throws Exception {
         ANDExpression expr = neverMatch1;
         expr.execute((AddEventTrigger) null, event1);
@@ -155,6 +166,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(matchSets.get(0).size() == 0);
     }
 
+    @Test
     public void testAddEventExecute_1event_nopartial() throws Exception {
         ANDExpression expr = neverMatch2_1;
         expr.execute((AddEventTrigger) null, event1);
@@ -166,7 +178,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).contains(event1));
     }
 
-
+    @Test
     public void testAddEventExecute_1event_partial_withdupe() throws Exception {
         ANDExpression expr = and2;
         expr.execute((AddEventTrigger) null, event1);
@@ -179,7 +191,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).contains(event1));
     }
 
-
+    @Test
     public void testAddEventExecute_1event_partial_nodupe() throws Exception {
         ANDExpression expr = neverMatch2_2;
         expr.execute((AddEventTrigger) null, event1);
@@ -191,7 +203,7 @@ public class ANDExpressionTest extends TestCase {
         assertFalse(matchSets.get(1).contains(event1));
     }
 
-
+    @Test
     public void testAddEventExecute_2event_match() throws Exception {
         ANDExpression expr = and2;
         expr.execute((AddEventTrigger) null, event1);
@@ -208,6 +220,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).contains(event2));
     }
 
+    @Test
     public void testAddEventExecute_2event_nomatch_falsefirst() throws Exception {
         ANDExpression expr = neverMatch2_1;
         expr.execute((AddEventTrigger) null, event1);
@@ -222,6 +235,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).contains(event2));
     }
 
+    @Test
     public void testAddEventExecute_2event_nomatch_truefirst() throws Exception {
         ANDExpression expr = neverMatch2_2;
         expr.execute((AddEventTrigger) null, event1);
@@ -237,6 +251,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).size() == 0);
     }
 
+    @Test
     public void testAddEventExecute_3event_matchtwice() throws Exception {
         ANDExpression expr = and2;
         expr.execute((AddEventTrigger) null, event1);
@@ -256,6 +271,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).contains(event3));
     }
 
+    @Test
     public void testAddEventExecute_2event_and_matched() throws Exception {
         ANDExpression expr = identityAnd;
         expr.execute((AddEventTrigger) null, event1);
@@ -268,6 +284,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).contains(event2));
     }
 
+    @Test
     public void testAddEventExecute_2event_reverse_matched() throws Exception {
         ANDExpression expr = identityAnd;
         expr.execute((AddEventTrigger) null, event2);
@@ -280,6 +297,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).contains(event2));
     }
 
+    @Test
     public void testAddEventExecute_dupe_ignored() throws Exception {
         ANDExpression expr = identityAnd;
         expr.registerAction(eventAction);
@@ -291,6 +309,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(eventMatches.size() == 1);
     }
 
+    @Test
     public void testRemoveEventExecute_remove1_empty() throws Exception {
         ANDExpression expr = and0;
         expr.execute((RemoveEventTrigger) null, event1);
@@ -299,6 +318,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(expr.isTrue());
     }
 
+    @Test
     public void testRemoveEventExecute_remove1_matched1_false() throws Exception {
         ANDExpression expr = and1;
         expr.execute((AddEventTrigger) null, event1);
@@ -309,6 +329,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(matchSets.get(0).isEmpty());
     }
 
+    @Test
     public void testRemoveEventExecute_remove1_matched1_true1() throws Exception {
         ANDExpression expr = and1;
         expr.execute((AddEventTrigger) null, event1);
@@ -321,6 +342,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(matchSets.get(0).contains(event2));
     }
 
+    @Test
     public void testRemoveEventExecute_remove1_notmatched() throws Exception {
         ANDExpression expr = neverMatch1;
         expr.execute((AddEventTrigger) null, event1);
@@ -330,6 +352,8 @@ public class ANDExpressionTest extends TestCase {
         List<EventSet> matchSets = expr.getMatchEvents();
         assertTrue(matchSets.get(0).isEmpty());
     }
+
+    @Test
     public void testRemoveEventExecute_remove1_matched1_partial1() throws Exception {
         ANDExpression expr = neverMatch2_2;
         expr.execute((AddEventTrigger) null, event1);
@@ -344,6 +368,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).isEmpty());
     }
 
+    @Test
     public void testRemoveEventExecute_remove1_matched1_partial2() throws Exception {
         ANDExpression expr = and2;
         expr.execute((AddEventTrigger) null, event1);
@@ -360,6 +385,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).contains(event2));
     }
 
+    @Test
     public void testRemoveEventExecute_remove2_matched2_false() throws Exception {
         ANDExpression expr = and2;
         expr.execute((AddEventTrigger) null, event1);
@@ -373,6 +399,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).isEmpty());
     }
 
+    @Test
     public void testRemoveEventExecute_remove1_matched1_true2() throws Exception {
         ANDExpression expr = and2;
         expr.execute((AddEventTrigger) null, event1);
@@ -390,6 +417,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).contains(event3));
     }
 
+    @Test
     public void testRemoveEventExecute_remove2_notmatched() throws Exception {
         ANDExpression expr = neverMatch2_1;
         expr.execute((AddEventTrigger) null, event1);
@@ -403,6 +431,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).isEmpty());
     }
 
+    @Test
     public void testRemoveEventExecute_remove2_partial() throws Exception {
         ANDExpression expr = neverMatch2_2;
         expr.execute((AddEventTrigger) null, event1);
@@ -416,6 +445,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).isEmpty());
     }
 
+    @Test
     public void testClear_empty() throws Exception {
         and0.clear();
         assertTrue(and0.getParts().size() == 0);
@@ -428,6 +458,7 @@ public class ANDExpressionTest extends TestCase {
     public void testReset() throws Exception {
     }
 
+    @Test
     public void testEventMatchRegisterAction_1event_1expr_1matched() throws Exception {
         ANDExpression expr = and1;
         expr.registerAction(eventAction);
@@ -436,6 +467,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(eventMatches.contains(event1));
     }
 
+    @Test
     public void testEventMatchRegisterAction_2event_1expr_2matched() throws Exception {
         ANDExpression expr = and1;
         expr.registerAction(eventAction);
@@ -446,6 +478,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(eventMatches.contains(event2));
     }
 
+    @Test
     public void testEventMatchRegisterAction_2event_2expr_both_matched() throws Exception {
         ANDExpression expr = and2;
         expr.registerAction(eventAction);
@@ -456,6 +489,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(eventMatches.contains(event2));
     }
 
+    @Test
     public void testEventMatchRegisterAction_2event_2expr_each_matched() throws Exception {
         ANDExpression expr = identityAnd;
         expr.registerAction(eventAction);
@@ -465,10 +499,12 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(eventMatches.contains(event2));
     }
 
+    @Test
     public void testEventMatchUnregisterAction() throws Exception {
 
     }
 
+    @Test
     public void testComplexExpressionMatchRegisterAction_1event_1expr_1matched() throws Exception {
         ANDExpression expr = and1;
         expr.registerAction(complexAction);
@@ -478,6 +514,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(complexMatches.get(0).getCombinations().contains(comb_1));
     }
 
+    @Test
     public void testComplexExpressionMatchRegisterAction_2event_1expr_2matched() throws Exception {
         ANDExpression expr = and1;
         expr.registerAction(complexAction);
@@ -490,6 +527,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(complexMatches.get(1).getCombinations().contains(comb_2));
     }
 
+    @Test
     public void testComplexExpressionMatchRegisterAction_2event_2expr_both_matched() throws Exception {
         ANDExpression expr = and2;
         expr.registerAction(complexAction);
@@ -505,6 +543,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(complexMatches.get(1).getCombinations().contains(comb_2_2));
     }
 
+    @Test
     public void testComplexExpressionMatchRegisterAction_2event_2expr_each_matched() throws Exception {
         ANDExpression expr = identityAnd;
         expr.registerAction(complexAction);
@@ -515,6 +554,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(complexMatches.get(0).getCombinations().contains(comb_1_2));
     }
 
+    @Test
     public void testComplexExpressionMatchRegisterAction_3event_2expr_all_matched() throws Exception {
         ANDExpression expr = and2;
         expr.registerAction(complexAction);
@@ -536,6 +576,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(complexMatches.get(2).getCombinations().contains(comb_3_3));
     }
 
+    @Test
     public void testComplexExpressionMatchRegisterAction_3event_2expr_mixed_match() throws Exception {
         ANDExpression expr = oridentityAnd;
         expr.registerAction(complexAction);
@@ -554,6 +595,7 @@ public class ANDExpressionTest extends TestCase {
         assertTrue(complexMatches.get(2).getCombinations().contains(comb_1_3));
     }
 
+    @Test
     public void testComplexExpressionMatchRegisterAction_4event_2expr_mixed_match() throws Exception {
         ANDExpression expr = oridentityAnd;
         expr.registerAction(complexAction);
@@ -568,6 +610,7 @@ public class ANDExpressionTest extends TestCase {
     }
 
 
+    @Test
     public void testComplexMatchUnregisterAction() throws Exception {
 
     }

--- a/src/test/java/com/eventswarm/expressions/SequenceExpressionTest.java
+++ b/src/test/java/com/eventswarm/expressions/SequenceExpressionTest.java
@@ -23,6 +23,9 @@ import com.eventswarm.events.Event;
 import com.eventswarm.events.jdo.JdoCombination;
 import com.eventswarm.eventset.EventSet;
 import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.After;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -69,6 +72,7 @@ public class SequenceExpressionTest extends TestCase {
         }
     };
 
+    @Before
     public void setUp() throws Exception {
         sequence0 = new SequenceExpression(new ArrayList<EventExpression>());
         sequence1 = new SequenceExpression(Arrays.asList(new EventExpression[] {expr_true1}));
@@ -90,14 +94,17 @@ public class SequenceExpressionTest extends TestCase {
         comb_empty = new JdoCombination();
     }
 
+    @After
     public void tearDown() throws Exception {
 
     }
 
+    @Test
     public void testIsTrue_empty() throws Exception {
         assertTrue(sequence0.isTrue());
     }
 
+    @Test
     public void testIsTrue_1expr_0event() throws Exception {
         assertEquals(1, sequence1.expressions.size());
         assertEquals(1, sequence1.eventSets.size());
@@ -105,20 +112,24 @@ public class SequenceExpressionTest extends TestCase {
         assertFalse(sequence1.isTrue());
     }
 
+    @Test
     public void testIsTrue_2expr_0event() throws Exception {
         assertFalse(sequence2.isTrue());
     }
 
+    @Test
     public void testGetPartsAsList_empty() throws Exception {
         assertTrue(sequence0.getPartsAsList().size() == 0);
     }
 
+    @Test
     public void testGetPartsAsList_single() throws Exception {
         List<EventExpression> parts = sequence1.getPartsAsList();
         assertEquals(1, parts.size());
         assertEquals(expr_true1, parts.get(0));
     }
 
+    @Test
     public void testGetPartsAsList_multiple() throws Exception {
         List<EventExpression> parts =  sequence2.getPartsAsList();
         assertTrue(parts.size() == 2);
@@ -126,12 +137,14 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(parts.get(1) == expr_true3);
     }
 
+    @Test
     public void testAddEventExecute_empty() throws Exception {
         sequence0.execute((AddEventTrigger) null, event1);
         assertTrue(sequence0.isTrue());
         assertTrue(sequence0.getMatchEvents().size() == 0);
     }
 
+    @Test
     public void testAddEventExecute_1event_match() throws Exception {
         SequenceExpression expr = sequence1;
         expr.execute((AddEventTrigger) null, event1);
@@ -142,6 +155,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(matchSets.get(0).contains(event1));
     }
 
+    @Test
     public void testAddEventExecute_1event_nomatch() throws Exception {
         SequenceExpression expr = neverMatch1;
         expr.execute((AddEventTrigger) null, event1);
@@ -151,6 +165,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(matchSets.get(0).size() == 0);
     }
 
+    @Test
     public void testAddEventExecute_1event_nopartial() throws Exception {
         SequenceExpression expr = neverMatch2_1;
         expr.execute((AddEventTrigger) null, event1);
@@ -162,6 +177,7 @@ public class SequenceExpressionTest extends TestCase {
     }
 
 
+    @Test
     public void testAddEventExecute_1event_partial_withdupe() throws Exception {
         SequenceExpression expr = sequence2;
         expr.execute((AddEventTrigger) null, event1);
@@ -174,6 +190,7 @@ public class SequenceExpressionTest extends TestCase {
     }
 
 
+    @Test
     public void testAddEventExecute_1event_partial_nodupe() throws Exception {
         SequenceExpression expr = neverMatch2_2;
         expr.execute((AddEventTrigger) null, event1);
@@ -186,6 +203,7 @@ public class SequenceExpressionTest extends TestCase {
     }
 
 
+    @Test
     public void testAddEventExecute_2event_match() throws Exception {
         SequenceExpression expr = sequence2;
         expr.execute((AddEventTrigger) null, event1);
@@ -202,6 +220,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).contains(event2));
     }
 
+    @Test
     public void testAddEventExecute_2event_nomatch_falsefirst() throws Exception {
         SequenceExpression expr = neverMatch2_1;
         expr.execute((AddEventTrigger) null, event1);
@@ -214,6 +233,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).size() == 0);
     }
 
+    @Test
     public void testAddEventExecute_2event_nomatch_truefirst() throws Exception {
         SequenceExpression expr = neverMatch2_2;
         expr.execute((AddEventTrigger) null, event1);
@@ -229,6 +249,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).size() == 0);
     }
 
+    @Test
     public void testAddEventExecute_3event_matchtwice() throws Exception {
         SequenceExpression expr = sequence2;
         expr.execute((AddEventTrigger) null, event1);
@@ -248,6 +269,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).contains(event3));
     }
 
+    @Test
     public void testAddEventExecute_2event_sequence_matched() throws Exception {
         SequenceExpression expr = identitySequence;
         expr.execute((AddEventTrigger) null, event1);
@@ -260,6 +282,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).contains(event2));
     }
 
+    @Test
     public void testAddEventExecute_2event_sequence_notmatched() throws Exception {
         SequenceExpression expr = identitySequence;
         expr.execute((AddEventTrigger) null, event2);
@@ -271,6 +294,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).isEmpty());
     }
 
+    @Test
     public void testAddEventExecute_dupe_ignored() throws Exception {
         SequenceExpression expr = identitySequence;
         expr.registerAction(eventAction);
@@ -282,6 +306,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(eventMatches.size() == 1);
     }
 
+    @Test
     public void testRemoveEventExecute_remove1_empty() throws Exception {
         SequenceExpression expr = sequence0;
         expr.execute((RemoveEventTrigger) null, event1);
@@ -290,6 +315,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(expr.isTrue());
     }
 
+    @Test
     public void testRemoveEventExecute_remove1_matched1_false() throws Exception {
         SequenceExpression expr = sequence1;
         expr.execute((AddEventTrigger) null, event1);
@@ -300,6 +326,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(matchSets.get(0).isEmpty());
     }
 
+    @Test
     public void testRemoveEventExecute_remove1_matched1_true1() throws Exception {
         SequenceExpression expr = sequence1;
         expr.execute((AddEventTrigger) null, event1);
@@ -312,6 +339,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(matchSets.get(0).contains(event2));
     }
 
+    @Test
     public void testRemoveEventExecute_remove1_notmatched() throws Exception {
         SequenceExpression expr = neverMatch1;
         expr.execute((AddEventTrigger) null, event1);
@@ -321,6 +349,7 @@ public class SequenceExpressionTest extends TestCase {
         List<EventSet> matchSets = expr.getMatchEvents();
         assertTrue(matchSets.get(0).isEmpty());
     }
+    @Test
     public void testRemoveEventExecute_remove1_matched1_partial1() throws Exception {
         SequenceExpression expr = neverMatch2_2;
         expr.execute((AddEventTrigger) null, event1);
@@ -335,6 +364,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).isEmpty());
     }
 
+    @Test
     public void testRemoveEventExecute_remove1_matched1_partial2() throws Exception {
         SequenceExpression expr = sequence2;
         expr.execute((AddEventTrigger) null, event1);
@@ -349,6 +379,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).isEmpty());
     }
 
+    @Test
     public void testRemoveEventExecute_remove2_matched2_false() throws Exception {
         SequenceExpression expr = sequence2;
         expr.execute((AddEventTrigger) null, event1);
@@ -362,6 +393,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).isEmpty());
     }
 
+    @Test
     public void testRemoveEventExecute_remove1_matched1_true2() throws Exception {
         SequenceExpression expr = sequence2;
         expr.execute((AddEventTrigger) null, event1);
@@ -378,6 +410,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).contains(event3));
     }
 
+    @Test
     public void testRemoveEventExecute_remove2_notmatched() throws Exception {
         SequenceExpression expr = neverMatch2_1;
         expr.execute((AddEventTrigger) null, event1);
@@ -391,6 +424,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).isEmpty());
     }
 
+    @Test
     public void testRemoveEventExecute_remove2_partial() throws Exception {
         SequenceExpression expr = neverMatch2_2;
         expr.execute((AddEventTrigger) null, event1);
@@ -404,18 +438,22 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(matchSets.get(1).isEmpty());
     }
 
+    @Test
     public void testClear_empty() throws Exception {
         sequence0.clear();
         assertTrue(sequence0.getParts().size() == 0);
         assertTrue(sequence0.getMatchEvents().size() == 0);
     }
 
+    @Test
     public void testClear_single() throws Exception {
     }
 
+    @Test
     public void testReset() throws Exception {
     }
 
+    @Test
     public void testEventMatchRegisterAction_1event_1expr_1matched() throws Exception {
         SequenceExpression expr = sequence1;
         expr.registerAction(eventAction);
@@ -424,6 +462,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(eventMatches.contains(event1));
     }
 
+    @Test
     public void testEventMatchRegisterAction_2event_1expr_2matched() throws Exception {
         SequenceExpression expr = sequence1;
         expr.registerAction(eventAction);
@@ -434,6 +473,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(eventMatches.contains(event2));
     }
 
+    @Test
     public void testEventMatchRegisterAction_2event_2expr_both_matched() throws Exception {
         SequenceExpression expr = sequence2;
         expr.registerAction(eventAction);
@@ -443,6 +483,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(eventMatches.contains(event2));
     }
 
+    @Test
     public void testEventMatchRegisterAction_2event_2expr_each_matched() throws Exception {
         SequenceExpression expr = identitySequence;
         expr.registerAction(eventAction);
@@ -452,10 +493,12 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(eventMatches.contains(event2));
     }
 
+    @Test
     public void testEventMatchUnregisterAction() throws Exception {
 
     }
 
+    @Test
     public void testComplexExpressionMatchRegisterAction_1event_1expr_1matched() throws Exception {
         SequenceExpression expr = sequence1;
         expr.registerAction(complexAction);
@@ -465,6 +508,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(complexMatches.get(0).getCombinations().contains(comb_1));
     }
 
+    @Test
     public void testComplexExpressionMatchRegisterAction_2event_1expr_2matched() throws Exception {
         SequenceExpression expr = sequence1;
         expr.registerAction(complexAction);
@@ -477,6 +521,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(complexMatches.get(1).getCombinations().contains(comb_2));
     }
 
+    @Test
     public void testComplexExpressionMatchRegisterAction_2event_2expr_both_matched() throws Exception {
         SequenceExpression expr = sequence2;
         expr.registerAction(complexAction);
@@ -488,6 +533,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(complexMatches.get(0).getCombinations().contains(comb_1_2));
     }
 
+    @Test
     public void testComplexExpressionMatchRegisterAction_2event_2expr_each_matched() throws Exception {
         SequenceExpression expr = identitySequence;
         expr.registerAction(complexAction);
@@ -498,6 +544,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(complexMatches.get(0).getCombinations().contains(comb_1_2));
     }
 
+    @Test
     public void testComplexExpressionMatchRegisterAction_3event_2expr_all_matched() throws Exception {
         SequenceExpression expr = sequence2;
         expr.registerAction(complexAction);
@@ -512,6 +559,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(complexMatches.get(1).getCombinations().contains(comb_2_3));
     }
 
+    @Test
     public void testComplexExpressionMatchRegisterAction_3event_2expr_mixed_match() throws Exception {
         SequenceExpression expr = orIdentitySequence;
         expr.registerAction(complexAction);
@@ -525,6 +573,7 @@ public class SequenceExpressionTest extends TestCase {
         assertTrue(complexMatches.get(1).getCombinations().contains(comb_1_3));
     }
 
+    @Test
     public void testComplexExpressionMatchRegisterAction_4event_2expr_mixed_match() throws Exception {
         SequenceExpression expr = orIdentitySequence;
         expr.registerAction(complexAction);
@@ -543,6 +592,7 @@ public class SequenceExpressionTest extends TestCase {
     }
 
 
+    @Test
     public void testComplexMatchUnregisterAction() throws Exception {
 
     }

--- a/src/test/java/com/eventswarm/expressions/TrueEventExpression.java
+++ b/src/test/java/com/eventswarm/expressions/TrueEventExpression.java
@@ -31,12 +31,8 @@ import com.eventswarm.events.Event;
 public class TrueEventExpression extends AbstractEventExpression {
 
     @Override
-    public void execute(AddEventTrigger trigger, Event event) {
-        // add the event to the set and fire the trigger
-        if (event != null) {
-            this.matches.add(event);
-        }
-        this.fire(event);
+    protected boolean matched(AddEventTrigger trigger, Event event) {
+        return true;
     }
 
     @Override

--- a/src/test/java/com/eventswarm/expressions/ValueGradientExpressionTest.java
+++ b/src/test/java/com/eventswarm/expressions/ValueGradientExpressionTest.java
@@ -18,6 +18,7 @@ package com.eventswarm.expressions;
 import com.eventswarm.AddEventTrigger;
 import com.eventswarm.abstractions.ValueRetriever;
 import com.eventswarm.events.Activity;
+import com.eventswarm.events.ComplexExpressionMatchEvent;
 import com.eventswarm.events.Event;
 import com.eventswarm.events.JsonEvent;
 import com.eventswarm.events.jdo.JdoHeader;
@@ -28,10 +29,13 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
-public class ValueGradientExpressionTest implements EventMatchAction {
+public class ValueGradientExpressionTest implements EventMatchAction, ComplexExpressionMatchAction {
   ValueRetriever<Double> retriever = new JsonEvent.DoubleRetriever("value");
   ArrayList<Event> matches = new ArrayList<Event>();
+  ArrayList<ComplexExpressionMatchEvent> complexMatches = new ArrayList<ComplexExpressionMatchEvent>();
   
   @Test
   public void testConstruct() {
@@ -43,7 +47,7 @@ public class ValueGradientExpressionTest implements EventMatchAction {
   @Test
   public void testNotEnough() {
     ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, -1);
-    subject.registerAction(this);
+    subject.registerAction((EventMatchAction) this);
     Event first = makeEvent(10.0);
     subject.execute((AddEventTrigger) null, first);
     assertEquals(0, matches.size());
@@ -52,7 +56,7 @@ public class ValueGradientExpressionTest implements EventMatchAction {
   @Test
   public void testMatchDown() {
     ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, -1);
-    subject.registerAction(this);
+    subject.registerAction((EventMatchAction) this);
     Event first = makeEvent(10.0);
     Event second = makeEvent(5.0);
     subject.execute((AddEventTrigger) null, first);
@@ -66,7 +70,7 @@ public class ValueGradientExpressionTest implements EventMatchAction {
   @Test
   public void testNotMatchDown() {
     ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, -1);
-    subject.registerAction(this);
+    subject.registerAction((EventMatchAction) this);
     Event first = makeEvent(5.0);
     Event second = makeEvent(10.0);
     subject.execute((AddEventTrigger) null, first);
@@ -78,7 +82,7 @@ public class ValueGradientExpressionTest implements EventMatchAction {
   @Test
   public void testMatchUp() {
     ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, 1);
-    subject.registerAction(this);
+    subject.registerAction((EventMatchAction) this);
     Event first = makeEvent(0.0);
     Event second = makeEvent(5.0);
     subject.execute((AddEventTrigger) null, first);
@@ -92,7 +96,7 @@ public class ValueGradientExpressionTest implements EventMatchAction {
   @Test
   public void testNotMatchUp() {
     ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, 1);
-    subject.registerAction(this);
+    subject.registerAction((EventMatchAction) this);
     Event first = makeEvent(5.0);
     Event second = makeEvent(0.0);
     subject.execute((AddEventTrigger) null, first);
@@ -103,7 +107,7 @@ public class ValueGradientExpressionTest implements EventMatchAction {
   @Test
   public void testMatchFlat() {
     ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, 0);
-    subject.registerAction(this);
+    subject.registerAction((EventMatchAction) this);
     Event first = makeEvent(1.0);
     Event second = makeEvent(1.0);
     subject.execute((AddEventTrigger) null, first);
@@ -117,7 +121,7 @@ public class ValueGradientExpressionTest implements EventMatchAction {
   @Test
   public void testNotMatchFlat() {
     ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, 0);
-    subject.registerAction(this);
+    subject.registerAction((EventMatchAction) this);
     Event first = makeEvent(5.0);
     Event second = makeEvent(10.0);
     subject.execute((AddEventTrigger) null, first);
@@ -128,7 +132,7 @@ public class ValueGradientExpressionTest implements EventMatchAction {
   @Test
   public void testNextMatch() {
     ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, 1);
-    subject.registerAction(this);
+    subject.registerAction((EventMatchAction) this);
     Event first = makeEvent(5.0);
     Event second = makeEvent(10.0);
     Event third = makeEvent(15.0);
@@ -144,7 +148,7 @@ public class ValueGradientExpressionTest implements EventMatchAction {
   @Test
   public void testMatchThenNotMatch() {
     ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, 1);
-    subject.registerAction(this);
+    subject.registerAction((EventMatchAction) this);
     Event first = makeEvent(5.0);
     Event second = makeEvent(10.0);
     Event third = makeEvent(5.0);
@@ -160,7 +164,7 @@ public class ValueGradientExpressionTest implements EventMatchAction {
   @Test
   public void testNotMatchThenMatch() {
     ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, 1);
-    subject.registerAction(this);
+    subject.registerAction((EventMatchAction) this);
     Event first = makeEvent(10.0);
     Event second = makeEvent(5.0);
     Event third = makeEvent(10.0);
@@ -174,9 +178,9 @@ public class ValueGradientExpressionTest implements EventMatchAction {
   }
 
   @Test
-  public void testIsTrue() {
+  public void testIsTrueFull() {
     ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, 1);
-    subject.registerAction(this);
+    subject.registerAction((EventMatchAction) this);
     Event first = makeEvent(5.0);
     Event second = makeEvent(10.0);
     Event third = makeEvent(15.0);
@@ -188,9 +192,9 @@ public class ValueGradientExpressionTest implements EventMatchAction {
   }
 
   @Test
-  public void testNotTrue() {
+  public void testNotTrueFull() {
     ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, 1);
-    subject.registerAction(this);
+    subject.registerAction((EventMatchAction) this);
     Event first = makeEvent(5.0);
     Event second = makeEvent(10.0);
     Event third = makeEvent(5.0);
@@ -202,9 +206,18 @@ public class ValueGradientExpressionTest implements EventMatchAction {
   }
 
   @Test
+  public void testIsTrueNotFull() {
+    ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, 1);
+    subject.registerAction((EventMatchAction) this);
+    Event first = makeEvent(5.0);
+    subject.execute((AddEventTrigger) null, first);
+    assertFalse(subject.isTrue());
+  }
+
+  @Test
   public void testHasMatched() {
     ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, 1);
-    subject.registerAction(this);
+    subject.registerAction((EventMatchAction) this);
     Event first = makeEvent(5.0);
     Event second = makeEvent(10.0);
     Event third = makeEvent(15.0);
@@ -225,7 +238,7 @@ public class ValueGradientExpressionTest implements EventMatchAction {
   @Test
   public void testOutOfOrderMatch() {
     ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, 1);
-    subject.registerAction(this);
+    subject.registerAction((EventMatchAction) this);
     Event first = makeEvent(5.0);
     Event second = makeEvent(10.0);
     subject.execute((AddEventTrigger) null, second);
@@ -239,7 +252,7 @@ public class ValueGradientExpressionTest implements EventMatchAction {
   @Test
   public void testSkippedMatch() throws Exception {
     ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, 1);
-    subject.registerAction(this);
+    subject.registerAction((EventMatchAction) this);
     Event first = makeEvent(5.0);
     Event second = makeEvent(10.0);
     Event third = makeEvent(15.0);
@@ -252,6 +265,136 @@ public class ValueGradientExpressionTest implements EventMatchAction {
     assertEquals(third, match.last());
   }
 
+  @Test
+  public void testGradientInAnd() {
+    ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, 1);
+    EventExpression[] seq = {subject, new TrueEventExpression()};
+    ANDExpression and = new ANDExpression(Arrays.asList(seq));
+    and.registerAction((ComplexExpressionMatchAction) this);
+    and.registerAction((EventMatchAction) this);
+    Event first = makeEvent(0.0);
+    Event second = makeEvent(5.0);
+    and.execute((AddEventTrigger) null, first);
+    and.execute((AddEventTrigger) null, second);
+    assertTrue(and.isTrue());
+    assertEquals(1, complexMatches.size());
+    assertEquals(1, matches.size());
+    assertEquals(second, matches.get(0));
+    Activity gradient = (Activity) complexMatches.get(0).getEvents().first();
+    assertEquals(first, gradient.first());
+    assertEquals(second, gradient.last());
+  }
+
+
+  @Test
+  public void testNoGradientInAnd() {
+    ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, 1);
+    EventExpression[] seq = {subject, new TrueEventExpression()};
+    ANDExpression and = new ANDExpression(Arrays.asList(seq));
+    and.registerAction((ComplexExpressionMatchAction) this);
+    and.registerAction((EventMatchAction) this);
+    Event first = makeEvent(0.0);
+    and.execute((AddEventTrigger) null, first);
+    assertFalse(and.isTrue());
+    assertEquals(0, complexMatches.size());
+    assertEquals(0, matches.size());
+  }
+
+  @Test
+  public void testGradientInSequenceOverlap() {
+    ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, 1);
+    EventExpression[] seq = {subject, new TrueEventExpression()};
+    SequenceExpression sequence = new SequenceExpression(Arrays.asList(seq));
+    sequence.registerAction((ComplexExpressionMatchAction) this);
+    sequence.registerAction((EventMatchAction) this);
+    Event first = makeEvent(0.0);
+    Event second = makeEvent(5.0);
+    Event third = makeEvent(10.0);
+    sequence.execute((AddEventTrigger) null, first);
+    sequence.execute((AddEventTrigger) null, second);
+    sequence.execute((AddEventTrigger) null, third);
+    assertTrue(sequence.isTrue());
+    assertEquals(1, complexMatches.size());
+    assertEquals(1, matches.size());
+    assertEquals(third, matches.get(0));
+    Activity gradient = (Activity) complexMatches.get(0).getEvents().first();
+    assertEquals(first, gradient.first());
+    assertEquals(second, gradient.last());
+  }
+
+
+  @Test
+  public void testGradientInSequenceDistinct() {
+    ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, 1);
+    EventExpression[] seq = {subject, new TrueEventExpression()};
+    SequenceExpression sequence = new SequenceExpression(Arrays.asList(seq));
+    sequence.registerAction((ComplexExpressionMatchAction) this);
+    sequence.registerAction((EventMatchAction) this);
+    Event first = makeEvent(0.0);
+    Event second = makeEvent(5.0);
+    Event third = makeEvent(0.0);
+    sequence.execute((AddEventTrigger) null, first);
+    sequence.execute((AddEventTrigger) null, second);
+    sequence.execute((AddEventTrigger) null, third);
+    assertTrue(sequence.isTrue());
+    assertEquals(1, complexMatches.size());
+    assertEquals(1, matches.size());
+    assertEquals(third, matches.get(0));
+    Activity gradient = (Activity) complexMatches.get(0).getEvents().first();
+    assertEquals(first, gradient.first());
+    assertEquals(second, gradient.last());
+  }
+
+  @Test
+  public void testGradientInSequenceFiltered() throws Exception {
+    ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, 1);
+    EventExpression[] seq = {subject, new TrueEventExpression()};
+    SequenceExpression sequence = new SequenceExpression(Arrays.asList(seq));
+    sequence.registerAction((ComplexExpressionMatchAction) this);
+    sequence.registerAction((EventMatchAction) this);
+    Event first = makeEvent(0.0);
+    Event second = makeEvent(5.0);
+    Event third = new OrgJsonEvent(JdoHeader.getLocalHeader(), new JSONObject("{}")); // event that won't match gradient
+    sequence.execute((AddEventTrigger) null, first);
+    sequence.execute((AddEventTrigger) null, second);
+    sequence.execute((AddEventTrigger) null, third);
+    assertTrue(sequence.isTrue());
+    assertEquals(1, complexMatches.size());
+    assertEquals(1, matches.size());
+    assertEquals(third, matches.get(0));
+    Activity gradient = (Activity) complexMatches.get(0).getEvents().first();
+    assertEquals(first, gradient.first());
+    assertEquals(second, gradient.last());
+  }
+
+
+  @Test
+  public void testGradientInSequenceWithIntervening() throws Exception {
+    ValueGradientExpression<Double> subject = new ValueGradientExpression<Double>(2, retriever, 1);
+    EventExpression[] seq = {subject, new TrueEventExpression()};
+    SequenceExpression sequence = new SequenceExpression(Arrays.asList(seq));
+    sequence.registerAction((ComplexExpressionMatchAction) this);
+    sequence.registerAction((EventMatchAction) this);
+    Event first = makeEvent(0.0);
+    Event second = makeEvent(5.0);
+    Event third = makeEvent(0.0);
+    Event fourth = new OrgJsonEvent(JdoHeader.getLocalHeader(), new JSONObject("{}")); // event that won't match gradient
+    sequence.execute((AddEventTrigger) null, first);
+    sequence.execute((AddEventTrigger) null, second);
+    sequence.execute((AddEventTrigger) null, third);
+    sequence.execute((AddEventTrigger) null, fourth);
+    assertTrue(sequence.isTrue());
+    assertEquals(2, complexMatches.size());
+    assertEquals(2, matches.size());
+    assertEquals(third, matches.get(0));
+    assertEquals(fourth, matches.get(1));
+    Activity gradient = (Activity) complexMatches.get(0).getEvents().first();
+    assertEquals(first, gradient.first());
+    assertEquals(second, gradient.last());
+    gradient = (Activity) complexMatches.get(1).getEvents().first();
+    assertEquals(first, gradient.first());
+    assertEquals(second, gradient.last());
+  }
 
   public Event makeEvent(Double value) {
     return new OrgJsonEvent(JdoHeader.getLocalHeader(), new JSONObject("{'value': " + value.toString() + "}"));
@@ -259,5 +402,9 @@ public class ValueGradientExpressionTest implements EventMatchAction {
 
   public void execute(EventMatchTrigger trigger, Event event) {
     matches.add(event);
+  }
+
+  public void execute(ComplexExpressionMatchTrigger trigger, ComplexExpressionMatchEvent event) {
+    complexMatches.add(event);
   }
 }


### PR DESCRIPTION
There were a few issues arising from including a ValueGradientExpression, which matches activities (sets of events), in a SequenceExpression. This PR fixes those issues, specifically:

* bugs in the ordering semantics for Activity (inconsistent with event ordering and not considering concurrency of events)
* updated various test classes to use JUnit annotations
* minor fix to TrueExpression to improve robustness
* better debug output from SequenceExpression and ANDExpression